### PR TITLE
Feature/populate team with IDs

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -823,6 +823,7 @@ function idToName( slugs ) {
         for ( const mon in pokemonData ) {
             if ( Number( pokemonData[mon].base_id ) === Number( slug ) ) {
                 slugs[ i ] = mon;
+                break;
             }
         }
     });

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -821,7 +821,7 @@ function idToName( slugs ) {
         if ( isNaN( slug ) ) { return };
         // Change slug from id to name if possible
         for ( const mon in pokemonData ) {
-            if ( Number( pokemonData.mon.base_id ) === Number( slug ) ) {
+            if ( Number( pokemonData[mon].base_id ) === Number( slug ) ) {
                 slugs[ i ] = mon;
             }
         }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -51,6 +51,7 @@ function buildPage() {
     }
     completeTypeData();
     completePokemonData();
+    slugs = idToName( slugs );
     populateTeam( document.querySelector( ".head" ) );
     populateTeraPicker( document.querySelector( ".slot__toggle-container" ) );
     populateDexes( document.querySelector( ".tail" ) );
@@ -805,6 +806,28 @@ function createPokemonEntry( slug, pokemon ) {
         return [ li, clone ];
     }
     return [ li ];
+}
+
+/**
+ * Given an array of slugs (ids or names), replace the ids with
+ * corresponding names if possible. If a slug is an id, only keep it when a matching
+ * name has been found to replace it.
+ * @param {string[]} slugs
+ * @return {string[]} Formated slugs array with names instead of ids
+ */
+function idToName( slugs ) {
+    slugs.forEach( ( slug, i ) => {
+        // Not a number means probably a name, ignore
+        if ( isNaN( slug ) ) { return };
+        // Change slug from id to name if possible
+        for ( const mon in pokemonData ) {
+            if ( Number( mon.base_id ) === Number( slug ) ) {
+                slugs[ i ] = mon.name.toLowerCase();
+            }
+        }
+    });
+    // Only keep a slug when a matching name has replaced the id
+    return slugs.filter( slug => { isNaN( slug ) } );
 }
 
 /**

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -51,7 +51,6 @@ function buildPage() {
     }
     completeTypeData();
     completePokemonData();
-    slugs = idToName( slugs );
     populateTeam( document.querySelector( ".head" ) );
     populateTeraPicker( document.querySelector( ".slot__toggle-container" ) );
     populateDexes( document.querySelector( ".tail" ) );
@@ -809,26 +808,29 @@ function createPokemonEntry( slug, pokemon ) {
 }
 
 /**
- * Given an array of slugs (ids or names), replace the ids with
- * corresponding names if possible. If a slug is an id, only keep it when a matching
- * name has been found to replace it.
- * @param {string[]} slugs
- * @return {string[]} Formated slugs array with names instead of ids
+ * Given an array of IDs or slugs, replace the IDs with corresponding slugs if possible.
+ * If an input is an ID, only keep it when a matching slug has been found to replace it.
+ * @param {string[]} ids_or_slugs
+ * @return {string[]} Formated slugs array with names instead of IDs
  */
-function idToName( slugs ) {
-    slugs.forEach( ( slug, i ) => {
-        // Not a number means probably a name, ignore
-        if ( isNaN( slug ) ) { return };
-        // Change slug from id to name if possible
-        for ( const mon in pokemonData ) {
-            if ( Number( pokemonData[mon].base_id ) === Number( slug ) ) {
-                slugs[ i ] = mon;
+function idToSlug( ids_or_slugs ) {
+    const slugs = [];
+    ids_or_slugs.forEach( ( id_or_slug ) => {
+        // Not a number means probably a slug
+        if ( isNaN( id_or_slug ) ) {
+            slugs.push( id_or_slug );
+            return;
+        };
+        // Convert ID to slug if possible
+        const base_id = parseInt( id_or_slug );
+        for ( const slug in pokemonData ) {
+            if ( pokemonData[ slug ].base_id === base_id ) {
+                slugs.push( slug );
                 break;
             }
         }
     });
-    // Only keep a slug when a matching name has replaced the id
-    return slugs.filter( slug => isNaN( slug ) );
+    return slugs;
 }
 
 /**
@@ -1684,6 +1686,7 @@ function updateTeamAnalysis() {
                     ? gameData[ game ].versions.map( ver => ver.slug )
                     : [];
                 slugs = slugs.slice( 1 );  // Remove hash
+                slugs = idToSlug( slugs );  // Convert IDs (if any) to slugs
                 return [ game, versions, slugs ]
             }
         }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -821,8 +821,8 @@ function idToName( slugs ) {
         if ( isNaN( slug ) ) { return };
         // Change slug from id to name if possible
         for ( const mon in pokemonData ) {
-            if ( Number( mon.base_id ) === Number( slug ) ) {
-                slugs[ i ] = mon.name.toLowerCase();
+            if ( Number( pokemonData.mon.base_id ) === Number( slug ) ) {
+                slugs[ i ] = mon;
             }
         }
     });

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -828,7 +828,7 @@ function idToName( slugs ) {
         }
     });
     // Only keep a slug when a matching name has replaced the id
-    return slugs.filter( slug => { isNaN( slug ) } );
+    return slugs.filter( slug => isNaN( slug ) );
 }
 
 /**


### PR DESCRIPTION
Hi richi3f,

I wanted to use your planner to display a pokémon team made by a piece of code that I crafted for a project. 
(simply by redirecting to https://richi3f.github.io/pokemon-team-planner/plan/#bw+relavant+names+go+here)

The only problem was that I can't be certain that my program will output a team with the pokémons' names in english, (depends on some localized user input) but with pokedex IDs this problem would not exist at all.

With the changes I made to your main.js, a user can load the planner with english pokémon names as before, but also with pokedex IDs instead of english pokémon names, or a mix of both.

With how you worked out the team code, the IDs are replaced in the URL accordingly (with relevant names) as soon as the page loads.

I tested it and saw no issue when trying to break it.

You can try it if you want:
[/plan/#bw+25+00074+venonat+9999999999](https://surfingnet.github.io/pokemon-team-planner/plan/#bw+25+00074+venonat+9999999999)

Once merged I will delete the Github-Page of the fork I made of your work obviously.

Cheers o7