### PR TITLE
Fixed 'Tag' filter count excluding hidden checkboxes

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1269,7 +1269,7 @@ function changeCheckbox( event ) {
     // Update count in button
     const button = document.querySelector( "#" + name + "-filter" );
     const exceptAllSelector = selector + ":not([value='all'])";
-    const allOptions = document.querySelectorAll(  `${exceptAllSelector}:not(.dropdown-menu-item_hidden input)` );
+    const allOptions = document.querySelectorAll( `${exceptAllSelector}:not(.dropdown-menu-item_hidden input)` );
     const checkedOptions = document.querySelectorAll( `${exceptAllSelector}:checked:not(.dropdown-menu-item_hidden input)` );
     if ( allOptions.length === checkedOptions.length ) {
         const all = document.querySelector( selector + "[value='all']" );

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1269,8 +1269,8 @@ function changeCheckbox( event ) {
     // Update count in button
     const button = document.querySelector( "#" + name + "-filter" );
     const exceptAllSelector = selector + ":not([value='all'])";
-    const allOptions = document.querySelectorAll( exceptAllSelector );
-    const checkedOptions = document.querySelectorAll( exceptAllSelector + ":checked" );
+    const allOptions = document.querySelectorAll(  `${exceptAllSelector}:not(.dropdown-menu-item_hidden input)` );
+    const checkedOptions = document.querySelectorAll( `${exceptAllSelector}:checked:not(.dropdown-menu-item_hidden input)` );
     if ( allOptions.length === checkedOptions.length ) {
         const all = document.querySelector( selector + "[value='all']" );
         if ( all ) {


### PR DESCRIPTION
I noticed that for the Tag filter the "X selected" preview had an off-by-one error, so I updated the selectors to exclude hidden checkboxes since the "All Forms" checkbox was causing the error. Specifically, I changed lines 1272 and 1273 of main.js to filter out hidden checkboxes so that the preview would display a correct count. I've tested it locally and all functionality seems to be intact, including the "All Selected" preview updating properly with the "Misc. Forms". Thank you for this project, it's very useful!